### PR TITLE
Documentation update for Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 
 Serve resources from your SQL database using [`json-api`](https://github.com/ethanresnick/json-api/tree/v3-evolution-over-rewrite).
 
+## Installation
+
+```
+npm i @json-api/knex-adapter --save
+```
+
 ## How to Use
 
 ```js
 // index.js
 const { ResourceTypeRegistry, ResourceController } = require('jsonapi');
-const KnexAdapter = require('json-api-knex-adapter');
+const KnexAdapter = require('@json-api/knex-adapter');
 const express = require('express');
 const knex = require('knex');
 const models = require('./models');


### PR DESCRIPTION
Added how to install command
Updated the usage example

First of i just tried to install with `npm i json-api-knex-adapter` it took me a bit of research to figured this was moved to `@json-api/knex-adapter` so i added a install command to simplify this.

Then it came to usage, I was just trying mindlessly to grab the example but was not working with the version `1.0.0-beta.6` if you want any change to the PR please let me know.