### PR TITLE
Support for sorting by relationship attributes

### DIFF
--- a/src/find/apply-sorts.ts
+++ b/src/find/apply-sorts.ts
@@ -1,5 +1,5 @@
 import { QueryBuilder } from "knex";
-import { StrictModel, RelType } from "../models/model-interface";
+import { StrictModels, RelType, StrictModel } from "../models/model-interface";
 import { Error as APIError, FindQuery, Sort, FieldSort } from "json-api";
 
 /**
@@ -8,40 +8,111 @@ import { Error as APIError, FindQuery, Sort, FieldSort } from "json-api";
  */
 export default function applySorts(
   query: QueryBuilder,
-  model: StrictModel,
+  models: StrictModels,
+  primaryType: string,
   sorts: FindQuery['sort']
 ): void {
+
   if (sorts == null) return;
 
-  validateSorts(model, sorts);
+  validateSorts(models, primaryType, sorts);
 
   // Cast to FieldSort[] is checked by validateSorts()
+  const relationshipSortFields = [] as string[];
   for (const { field, direction } of sorts as FieldSort[]) {
-    const key = field === 'id' ? model.idKey : field;
-    query.orderBy(`${model.table}.${key}`, direction.toLowerCase());
+    if(!getValidKeys(models[primaryType]).includes(field)){
+      // must be field of relationship
+      relationshipSortFields.push(field); // track relationship sorts for joining
+      query.orderBy(field,direction.toLowerCase());
+    } else {
+      const key = field === 'id' ? models[primaryType].idKey : field;
+      query.orderBy(`${models[primaryType].table}.${key}`, direction.toLowerCase());
+    };
+    
   }
+  joinRequiredRelationshipsForSorts (query, models, primaryType, relationshipSortFields)
 };
 
-/**
- * Catch sorts of keys not in the model. Important for security as this prevents sorting by hidden,
- * private attributes, potentially resulting in data leakage.
- */
-function validateSorts(
-  model: StrictModel,
-  sorts: Sort[]
-): void {
-  const validKeys = [
+function getRelationshipTypeFromKey(model : StrictModel, key: string){
+  const relationship = model.relationships.find( relationship => relationship.key === key);
+   if(!relationship){
+    throw new APIError({
+      status: 400,
+      title: 'Invalid sort',
+      detail: `The relationship '${key}' does not exist on this model.'`
+    });
+  }
+  return relationship.type
+}
+
+function getValidKeys(model : StrictModel){
+  return [
     'id',
     ...model.attrs.map(attr => attr.key),
     ...model.relationships
       .filter(rel => rel.relType === RelType.MANY_TO_ONE)
       .map(rel => rel.key)
   ]
-  
-  const invalidSorts = sorts.filter(
-    sort => !('field' in sort) || !validKeys.includes(sort.field)
-  );
+}
 
+function joinRequiredRelationshipsForSorts(
+  query: QueryBuilder,
+  models: StrictModels,
+  primaryType: string,
+  sortFields: string[]
+){  
+  // join relationships that are referenced by sorts
+  const relationshipKeys = [...new Set(sortFields.map(field => field.substring(0,field.indexOf('.'))))]
+  relationshipKeys.forEach( relationshipKey => {
+    const relationshipType = getRelationshipTypeFromKey(models[primaryType], relationshipKey);
+    const relationshipTable = `${models[relationshipType].table}`;
+    const localFK = `${models[primaryType].table}.${relationshipKey}`;
+    const foreignPK = `${models[relationshipType].table}.${models[relationshipType].idKey}`;
+    query.leftJoin(relationshipTable, localFK, foreignPK);
+  })
+  // group by sorted relationship fields
+  sortFields.forEach(field => {
+    query.groupBy(field);
+  })
+}
+
+/**
+ * Catch sorts of keys not in the model. Important for security as this prevents sorting by hidden,
+ * private attributes, potentially resulting in data leakage.
+ */
+function validateSorts(
+  models: StrictModels,
+  primaryType: string,
+  sorts: Sort[]
+): void {
+  const validKeys = getValidKeys(models[primaryType]);
+  const invalidSorts = sorts.filter( sort => {
+    
+    if(!('field' in sort)){
+      return true;
+    } else if(!validKeys.includes(sort.field)){
+      
+      // not direct field match, check for relationship match
+      const relationshipKey = sort.field.substring(0,sort.field.indexOf('.'));
+      const relationshipField = sort.field.substring(sort.field.indexOf('.')+1);
+      // check if valid keys contains relationship name, 
+      if (!validKeys.includes(relationshipKey)){
+        return true
+      }
+      
+      // validate relationship field
+      const relationshipType = getRelationshipTypeFromKey(models[primaryType], relationshipKey);
+      let validRelationshipKeys;
+      if(relationshipType){
+        validRelationshipKeys = getValidKeys(models[relationshipType]);
+      }
+      
+      return !validRelationshipKeys.includes(relationshipField)
+    } else {
+      return false;
+    }
+  });
+  
   if (invalidSorts.length > 0) {
     throw invalidSorts.map(sort => new APIError({
       status: 400,

--- a/src/knex-adapter.ts
+++ b/src/knex-adapter.ts
@@ -92,7 +92,8 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
 
     applyFieldFilters(kq, model, selectedFields);
     joinToManyRelationships(kq, model, selectedFields);
-    applySorts(kq, model, query.sort);
+
+    applySorts(kq, this.models, query.type, query.sort);
 
     let records: any[];
     let included: ReturnedResource[];

--- a/src/knex-adapter.ts
+++ b/src/knex-adapter.ts
@@ -71,7 +71,7 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
     this.models = normalizeModels(models);
     this.knex = knex;
   }
-  
+
   async find(query: FindQuery): Promise<FindReturning> {
     const model = this.models[query.type];
     const kq = this.knex.from(model.table);
@@ -92,7 +92,6 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
 
     applyFieldFilters(kq, model, selectedFields);
     joinToManyRelationships(kq, model, selectedFields);
-
     applySorts(kq, this.models, query.type, query.sort);
 
     let records: any[];
@@ -148,7 +147,7 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
     const created = query.records.isSingular
       ? Data.pure<ReturnedResource>(results[0])
       : Data.of<ReturnedResource>(results);
-    
+
     return { created };
   }
 
@@ -170,10 +169,10 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
 
     const findQuery = getAfterUpdateFindQuery(query);
     const updated = (await this.find(findQuery)).primary;
-    
+
     return { updated }
   }
-  
+
   async delete(query: DeleteQuery): Promise<DeletionReturning> {
     if (!query.isSimpleIdQuery()) {
       throw new Error('Only simple ID queries are supported');
@@ -181,7 +180,7 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
 
     const model = this.models[query.type];
     const kq = this.knex(model.table).delete();
-    
+
     applyRecordFilters(kq, model, query.getFilters())
 
     let numDeleted;
@@ -199,23 +198,23 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
 
     return { deleted: undefined }
   }
-  
+
   async addToRelationship(query: AddToRelationshipQuery): Promise<any> {
 
   }
-  
+
   async removeFromRelationship(query: RemoveFromRelationshipQuery): Promise<any> {
 
   }
-  
+
   getModel(typeName: string): any {
 
   }
-  
+
   getRelationshipNames(typeName: string): string[] {
     return []
   }
-  
+
   async getTypePaths(items: {type: string, id: string}[]): Promise<TypeIdMapOf<TypeInfo>> {
     const itemsByType: any = _.groupBy(items, 'type')
     const result: TypeIdMapOf<TypeInfo> = {}
@@ -229,7 +228,7 @@ export default class KnexAdapter implements Adapter<typeof KnexAdapter> {
         }
       }
     }
-    
+
     return result
   }
 

--- a/test/integration/find.ts
+++ b/test/integration/find.ts
@@ -58,6 +58,19 @@ describe('integrated find', function() {
       expect(res.body.data[3].id).to.equal('000000000000000000000001');
     });
 
+    it('applies sort based on relationship attribute', async function () {
+      const res = await request(app)
+        .get('/posts?sort=author.name,id')
+        .accept('application/vnd.api+json')
+        .expect(200);
+
+      expect(res.body.data[0].id).to.equal('000000000000000000000004');
+      expect(res.body.data[1].id).to.equal('000000000000000000000001');
+      expect(res.body.data[2].id).to.equal('000000000000000000000002');
+      expect(res.body.data[3].id).to.equal('000000000000000000000003');
+      
+    });
+
     it.skip('populates relationships with include', async function() {
       const res = await request(app)
         .get('/posts')


### PR DESCRIPTION
Adding support to sort by relationship attributes involved:
 - Altering the sort validator to allow field sorts to be of format ``relationshipKey.relationshipField `` as long as relationshipKey is a valid relationship on the table, and that the relationshipField is a valid key of the related table.

- Any relationship attribute that was identified would result in the query having a ``leftjoin`` for the related table onto the primary table, in addition to an ``groupBy`` for the field that was sorted. 

- Added a test to check that sorting by attribute name, e.g ``author.name`` was valid. 