### PR TITLE
Allow includes to be combined with filters on linked relationships

### DIFF
--- a/src/find/join-to-many-relationships.ts
+++ b/src/find/join-to-many-relationships.ts
@@ -3,40 +3,65 @@ import { QueryBuilder } from "knex";
 import { getKnexFromQuery } from "../helpers/knex";
 
 /**
- * Applies appropriate joins to include ids for to-many relationships, and selects the ids as
- * text[] fields.
+ * Applies appropriate joins to include ids for to-many relationships.
  *
  * @param  {Query}    query  Knex QueryBuilder instance.
  * @param  {Object}   model  Model for type.
  * @param  {[String]} fields Fields to include for primary resource type, or an empty array if all fields should be included.
  * @return {Query}           Updated query.
  */
-export default function joinToManyRelationships(
+export function joinToManyRelationships(
   query: QueryBuilder,
   model: StrictModel,
   fields: string[]
 ): void {
-  const knex = getKnexFromQuery(query);
+  const rels = getLinkedRels(model, fields)
 
-  // Get requested to-many rels, or all to-many rels if no constraints are provided
-  const linkedRels = model.relationships.filter(
-    rel => rel.relType !== RelType.MANY_TO_ONE
-      && (fields.length === 0 || fields.includes(rel.key))
-  );
-
-  for (const rel of linkedRels) {
-    const { table, pk, fk } = rel.via as { table: string, pk: string, fk: string };
-    
-    query
-    .select(knex.raw(`array_agg(distinct "${table}"."${pk}"::text) as "${rel.key}"`))
-    .leftJoin(
+  for (const { via: { table, fk } } of rels) {
+    query.leftJoin(
       table,
       `${model.table}.${model.idKey}`,
       `${table}.${fk}`
     );
   }
-  
-  if (linkedRels.length > 0) {
+};
+
+/**
+ * Selects array_agg()s of the IDs in to-many relationships.
+ *
+ * @param  {Query}    query  Knex QueryBuilder instance.
+ * @param  {Object}   model  Model for request type.
+ * @param  {[String]} fields Fields to include for primary resource type, or an empty array if all fields should be included.
+ * @return {Query}           Updated query.
+ */
+export function selectToManyRelationships(
+  query: QueryBuilder,
+  model: StrictModel,
+  fields: string[]
+): void {
+  const knex = getKnexFromQuery(query);
+  const rels = getLinkedRels(model, fields);
+
+  for (const { key, via: { table, pk } } of rels) {
+    query.select(knex.raw(`array_agg(distinct "${table}"."${pk}"::text) as "${key}"`));
+  }
+
+  if (rels.length > 0) {
     query.groupBy(`${model.table}.${model.idKey}`);
   }
 };
+
+/**
+ * Get requested to-many rels, or all to-many rels if no constraints are provided
+ *
+ * @param  {Object}   model
+ * @param  {[String]} fields
+ * @return {[ToManyRelationship]}
+ */
+function getLinkedRels(model, fields) {
+  return model.relationships
+    .filter(
+      rel => rel.relType !== RelType.MANY_TO_ONE
+        && (fields.length === 0 || fields.includes(rel.key))
+    );
+}

--- a/test/integration/find.ts
+++ b/test/integration/find.ts
@@ -234,7 +234,7 @@ describe('integrated find', function() {
           .get('/posts?page[limit]=2&sort=id')
           .accept('application/vnd.api+json')
           .expect(200);
-        
+
         expect(res.body.data).to.have.lengthOf(2);
         expect(res.body.data[0].id).to.equal('000000000000000000000001');
         expect(res.body.data[1].id).to.equal('000000000000000000000002');
@@ -532,6 +532,34 @@ describe('integrated find', function() {
 
       expect(res.body.data).to.have.lengthOf(1);
       expect(res.body.included).to.have.lengthOf(4);
+    });
+
+    it('works with filters on attributes', async () => {
+      const res = await request(app)
+        .get('/posts')
+        .query('include=author&filter=(title,`Post 1`)')
+        .accept('application/vnd.api+json')
+        .expect(200);
+
+      expect(res.body.data).to.have.lengthOf(1);
+      expect(res.body.included).to.have.lengthOf(1);
+
+      expect(res.body.included[0].type).to.equal('authors');
+      expect(res.body.included[0].id).to.equal('000000000000000000000001');
+    });
+
+    it('works with filters on direct relationships', async () => {
+      const res = await request(app)
+        .get('/posts')
+        .query('include=author&filter=(tags,`000000000000000000000001`)')
+        .accept('application/vnd.api+json')
+        .expect(200);
+
+      expect(res.body.data).to.have.lengthOf(1);
+      expect(res.body.included).to.have.lengthOf(1);
+
+      expect(res.body.included[0].type).to.equal('authors');
+      expect(res.body.included[0].id).to.equal('000000000000000000000001');
     });
   });
 });


### PR DESCRIPTION
Previously we were basing the include queries off of the main query after filters had been applied but before to-many relationships had been joined. This resulted in a bug where trying to filter on a to-many relationship and use include at the same time would generate an include query that relied on the to-many relationship having been joined when it wasn't.

Request → `/posts?filter=(tag,1)&include=author`
Query → `SELECT author FROM posts WHERE post_tag.tag = 1`

Simply running the `joinToManyRelationships()` function on the query before processing include wouldn't work. Part of including the to-many relationships is SELECTing the aggregations of IDs. To make this work, I have to split that function into `joinToManyRelationships()` and `selectToManyRelationships()` where the former only adds the JOINs. With these in place, things start working as expected.

There is one possible optimisation here that I haven't made. When building the query to get the included resource IDs, we use the main query with all joins applied. Really all we need is the joins of fields we're using in the filter. I didn't bother optimising this as I assuming Postgres will have no problem figuring this out and avoiding the extra work.